### PR TITLE
Use rearc-quest.com for testing. Allow 15 minutes for DNS validation …

### DIFF
--- a/cf_waf_acm/main.tf
+++ b/cf_waf_acm/main.tf
@@ -127,9 +127,9 @@ resource "aws_acm_certificate_validation" "result" {
     for record in aws_route53_record.cert_validation : record.fqdn
   ]
 
-  // If this takes more than 5 minutes, something is probably wrong. Set to 10 minutes to allow for leeway. Default is 45 minutes.
+  // If this takes more than 5 minutes, something is probably wrong. Set to 15 minutes to allow for leeway. Default is 45 minutes.
   timeouts {
-    create = "10m"
+    create = "15m"
   }
 }
 

--- a/test_us-west-2.auto.tfvars
+++ b/test_us-west-2.auto.tfvars
@@ -1,2 +1,2 @@
 vpc_id = "vpc-c710b4a2"
-root_domain_name = "rearc.homewor.cc"
+root_domain_name = "rearc-quest.com"


### PR DESCRIPTION
…for ACM instead of 10 minutes.